### PR TITLE
Feature/s587 494

### DIFF
--- a/vda5050_connector/config/connector_example.yaml
+++ b/vda5050_connector/config/connector_example.yaml
@@ -1,20 +1,21 @@
 mqtt_bridge:
   ros__parameters:
-    mqtt_address: "localhost"
+    mqtt_address: "172.16.115.101" # "localhost"
     mqtt_port: 1883
     mqtt_username: ""
     mqtt_password: ""
-    manufacturer_name: "robots"
-    serial_number: "robot_1"
+    vda5050_protocol_version: "2.0.0"
+    manufacturer_name: "Navitec"
+    serial_number: "machine002"
 
 controller:
   ros__parameters:
-    robot_name: "robot_1"
-    manufacturer_name: "robots"
-    serial_number: "robot_1"
+    robot_name: "machine002Name"
+    manufacturer_name: "Navitec"
+    serial_number: "machine002"
 
 adapter:
   ros__parameters:
-    robot_name: "robot_1"
-    manufacturer_name: "robots"
-    serial_number: "robot_1"
+    robot_name: "machine002Name"
+    manufacturer_name: "Navitec"
+    serial_number: "machine002"

--- a/vda5050_connector/include/vda5050_connector/handler.hpp
+++ b/vda5050_connector/include/vda5050_connector/handler.hpp
@@ -97,13 +97,13 @@ public:
   }
 
   /**
-   * @brief Add a new information msg into the informations array of the order state
+   * @brief Add a new information msg into the information array of the order state
    * Only one thread/writer can modify the order_state.
    */
   void add_information(const vda5050_msgs::msg::Info & info)
   {
     std::unique_lock lock(mutex);
-    order_state_.informations.push_back(info);
+    order_state_.information.push_back(info);
   }
 
   /**
@@ -127,14 +127,14 @@ public:
   }
 
   /**
-   * @brief Clear the order state arrays (load, informations and errors).
+   * @brief Clear the order state arrays (load, information and errors).
    * Only one thread/writer can clear the order_state.
    */
   void clear()
   {
     std::unique_lock lock(mutex);
     order_state_.loads.clear();
-    order_state_.informations.clear();
+    order_state_.information.clear();
     order_state_.errors.clear();
   }
 

--- a/vda5050_connector/test/adapter/handler_execution/handler_execution_test.cpp
+++ b/vda5050_connector/test/adapter/handler_execution/handler_execution_test.cpp
@@ -72,14 +72,14 @@ TEST_F(AdapterTest, HandlerExecution)
 
   // Check handlers could modify global current state on configure
   auto order_state = adapter_node->get_current_state();
-  EXPECT_EQ(static_cast<int>(order_state.informations.size()), 1);
+  EXPECT_EQ(static_cast<int>(order_state.information.size()), 1);
   EXPECT_FLOAT_EQ(static_cast<int>(order_state.battery_state.battery_charge), 100.0);
 
   // Check handlers could modify global current state on execute
   ASSERT_NO_THROW(adapter_node->call_update_current_state());
   order_state = adapter_node->get_current_state();
-  // Update current state should clear previous loads, error and informations
-  EXPECT_EQ(static_cast<int>(order_state.informations.size()), 1);
+  // Update current state should clear previous loads, error and information
+  EXPECT_EQ(static_cast<int>(order_state.information.size()), 1);
   EXPECT_FLOAT_EQ(static_cast<int>(order_state.battery_state.battery_charge), 90.0);
 
   // Test vda action execute state machine: Transitions and call of state funcs

--- a/vda5050_connector/test/adapter/plugin_load/plugin_load_test.cpp
+++ b/vda5050_connector/test/adapter/plugin_load/plugin_load_test.cpp
@@ -105,7 +105,7 @@ TEST_F(AdapterTest, HandlerLoadHandlers)
 
   // Check handlers could modify global current state on configure
   auto order_state = adapter_node->get_current_state();
-  EXPECT_EQ(static_cast<int>(order_state.informations.size()), 1);
+  EXPECT_EQ(static_cast<int>(order_state.information.size()), 1);
   EXPECT_FLOAT_EQ(order_state.distance_since_last_node, 10.0);
   EXPECT_EQ(order_state.paused, true);
 

--- a/vda5050_connector/vda5050_connector_py/utils.py
+++ b/vda5050_connector/vda5050_connector_py/utils.py
@@ -110,7 +110,9 @@ def read_str_array_parameter(node: Node, param_name: str, alternative: list) -> 
         value=alternative,
     )
     param = node.get_parameter(param_name)
-    return param if type(param) == list else param.get_parameter_value().string_array_value
+    return (
+        param if type(param) == list else param.get_parameter_value().string_array_value
+    )
 
 
 def json_camel_to_snake_case(s):
@@ -126,6 +128,7 @@ def json_camel_to_snake_case(s):
         s (str|bytes): JSON message as string or bytes
 
     """
+
     def snake_case_dict(obj):
         """
         Replace dict camelCase keys by its snake case equivalent.
@@ -162,6 +165,7 @@ def json_snake_to_camel_case(s):
         s (str|bytes): JSON message as string or bytes
 
     """
+
     def to_camel_case(snake_str):
         """
         Convert snake case string to camel case.
@@ -221,7 +225,11 @@ def convert_ros_message_to_json(msg):
 
 
 def get_vda5050_mqtt_topic(
-    manufacturer, serial_number, topic, major_version, interface_name="uagv",
+    manufacturer,
+    serial_number,
+    topic,
+    major_version,
+    interface_name="uagv",
 ):
     """
     Return suggested VDA5050 MQTT topics.
@@ -275,7 +283,7 @@ def get_vda5050_mqtt_topic(
 
 
 def get_vda5050_ros2_topic(
-    manufacturer, serial_number, topic, interface_name="uagv", major_version="v1"
+    manufacturer, serial_number, topic, interface_name="uagv", major_version="v2"
 ):
     """
     Return ROS2 topics used for communication between controller and adapter.
@@ -306,7 +314,6 @@ def get_vda5050_ros2_topic(
 
     """
     mqtt_topic = get_vda5050_mqtt_topic(
-        manufacturer, serial_number, topic, major_version, interface_name)
-    return (
-        f"/{mqtt_topic}"
+        manufacturer, serial_number, topic, major_version, interface_name
     )
+    return f"/{mqtt_topic}"

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -1034,7 +1034,8 @@ class VDA5050Controller(Node):
             True if last <> first base nodes match, False otherwise.
 
         """
-        last_node = self._current_order.nodes[-1]
+        # get last node of the base order
+        last_node = next((node for node in reversed(self._current_order.nodes) if node.released), None)
         stitch_node = order.nodes[0]
 
         # Return False if node actions differ

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -669,7 +669,8 @@ class VDA5050Controller(Node):
                 "distance_since_last_node": order_state.state.distance_since_last_node,
                 "battery_state": order_state.state.battery_state,
                 "errors": current_errors + order_state.state.errors,
-                "information": order_state.state.information
+                "information": order_state.state.information,
+                "safety_state": order_state.state.safety_state
             }
         )
 

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -148,6 +148,9 @@ class VDA5050Controller(Node):
         """Configure resources needed by this node."""
         self._read_parameters()
 
+        self._active_pause = False
+        self._retry_current_goal = False
+
         self._cancel_action = None
         self._current_node_actions = []
         self._current_node_goal = None
@@ -835,6 +838,16 @@ class VDA5050Controller(Node):
         current_action: VDACurrentAction = action_result.result
         self._process_vda_action_goal_handle_dict.pop(current_action.action_id)
         self._update_action_status(current_action.action_id, current_action.action_status)
+
+        if (
+            current_action.action_type == "startPause"
+            and current_action.action_status == VDACurrentAction.FINISHED
+        ):
+            self.logger.info(f"KRT ------- Active pause")
+            self._set_active_pause(True)
+        elif current_action.action_status == VDACurrentAction.FINISHED:
+            self._set_active_pause(False)
+
         self.logger.info(f"VDA Action finished. Result: {current_action}")
 
     # Order
@@ -1086,10 +1099,14 @@ class VDA5050Controller(Node):
             and last_node_position.y == stitch_node_position.y
             and last_node_position.y == stitch_node_position.y
             and last_node_position.theta == stitch_node_position.theta
-            and (last_node_position.allowed_deviation_x_y ==
-                 stitch_node_position.allowed_deviation_x_y)
-            and (last_node_position.allowed_deviation_theta ==
-                 stitch_node_position.allowed_deviation_theta)
+            and (
+                last_node_position.allowed_deviation_x_y
+                == stitch_node_position.allowed_deviation_x_y
+            )
+            and (
+                last_node_position.allowed_deviation_theta
+                == stitch_node_position.allowed_deviation_theta
+            )
             and last_node_position.map_id == stitch_node_position.map_id
             and last_node_position.map_description == stitch_node_position.map_description
         )
@@ -1335,6 +1352,9 @@ class VDA5050Controller(Node):
         if not self._has_current_order():
             return
 
+        if self._has_active_pause():
+            return
+
         if len(self._current_node_actions) > 0:
             self._execute_node_actions()
             return
@@ -1444,9 +1464,10 @@ class VDA5050Controller(Node):
             for node in self._current_order.nodes
             if node.sequence_id == self._current_state.last_node_sequence_id + 2
         )
-        if next_node != self._current_node_goal:
+        if next_node != self._current_node_goal or self._retry_current_node():
             self.logger.info(f"Processing node: {next_node}")
 
+            self._set_retry_current_node(False)
             self.send_adapter_navigate_to_node(edge=next_edge, node=next_node)
         else:
             self.logger.error(f"{next_node} Already current goal")
@@ -1517,6 +1538,11 @@ class VDA5050Controller(Node):
 
         # When the order is cancelled, this callback should avoid continuing its logic
         if self._canceling_order():
+            return
+
+        if self._has_active_pause():
+            # if there is a pause, retry the current node after pause is stopped
+            self._set_retry_current_node(True)
             return
 
         last_edge = next(
@@ -1938,3 +1964,49 @@ class VDA5050Controller(Node):
         """Populate the localization parameter msg for the factsheet msg."""
         # TODO: This seems to be not defined in the VDA5050 schema.
         return 0
+
+    # Processing Helpers
+
+    def _set_active_pause(self, active: bool):
+        """
+        Set the active pause state.
+
+        Args:
+        ----
+            active (bool): True to set active pause, False to unset it.
+
+        """
+        self._active_pause = active
+
+    def _has_active_pause(self) -> bool:
+        """
+        Check if there is an active pause.
+
+        Returns
+        -------
+            True if there is an active pause, False otherwise.
+
+        """
+        return self._active_pause
+    
+    def _set_retry_current_node(self, retry: bool):
+        """
+        Set the retry current node state.
+
+        Args:
+        ----
+            retry (bool): True to set retry current node, False to unset it.
+
+        """
+        self._retry_current_goal = retry
+
+    def _retry_current_node(self) -> bool:
+        """
+        Check if there is a retry current node.
+
+        Returns
+        -------
+            True if there is a retry current node, False otherwise.
+
+        """
+        return self._retry_current_goal

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -669,7 +669,7 @@ class VDA5050Controller(Node):
                 "distance_since_last_node": order_state.state.distance_since_last_node,
                 "battery_state": order_state.state.battery_state,
                 "errors": current_errors + order_state.state.errors,
-                "informations": order_state.state.informations
+                "information": order_state.state.information
             }
         )
 

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -1194,10 +1194,8 @@ class VDA5050Controller(Node):
                 "order_id": order.order_id,
                 "order_update_id": order.order_update_id,
                 "errors": errors,
-                "node_states": (mode == OrderAcceptModes.STITCH) * self._current_state.node_states
-                + self._get_node_states(order),
-                "edge_states": (mode == OrderAcceptModes.STITCH) * self._current_state.edge_states
-                + self._get_edge_states(order),
+                "node_states": self._current_state.node_states + self._get_node_states(order),
+                "edge_states": self._current_state.edge_states + self._get_edge_states(order),
                 "action_states": self._current_state.action_states[:-len(order.nodes[0].actions)]
                 + self._get_action_states(order),
                 "new_base_request": False,

--- a/vda5050_msgs/msg/Edge.msg
+++ b/vda5050_msgs/msg/Edge.msg
@@ -30,6 +30,11 @@ float64 orientation                 # [rad] Orientation of the AGV on the edge r
                                     # If a trajectory without orientation and the orientation field here is defined,
                                     # apply the orientation to the tangent of the trajectory.
 
+string orientation_type             # Enum {GLOBAL, TANGENTIAL}: 
+                                    # "GLOBAL"- relative to the global project specific map coordinate system; 
+                                    # "TANGENTIAL"- tangential to the edge.
+                                    # If not defined, the default value is "TANGENTIAL"
+
 string direction                    # Sets direction at junctions for line-guided vehicles, to be defined initially
                                     # (vehicle individual) Example: left, right, straight, 433MHz
 

--- a/vda5050_msgs/msg/OrderState.msg
+++ b/vda5050_msgs/msg/OrderState.msg
@@ -65,7 +65,7 @@ string operating_mode                                # Enum {AUTOMATIC, SEMIAUTO
 
 vda5050_msgs/Error[] errors                          # Array of errorobjects. Empty array if there are no errors.
 
-vda5050_msgs/Info[] informations                     # Array of info-objects. An empty array indicates that the AGV has no information.
+vda5050_msgs/Info[] information                      # Array of info-objects. An empty array indicates that the AGV has no information.
                                                      # This should only be used for visualization or debugging – it must not be used for logic in master control
 
 vda5050_msgs/SafetyState safety_state                # Contains all safetyrelated information.

--- a/vda5050_msgs/msg/Trajectory.msg
+++ b/vda5050_msgs/msg/Trajectory.msg
@@ -1,6 +1,6 @@
 # Points defining a spline. Theta allows holonomic vehicles to rotate along the trajecotry.
 
-float64 degree 1.0                        # Range: [1 … infinity) Defines the number of control points that influence
+int32 degree 1                              # Range: [1 … infinity) Defines the number of control points that influence
                                           # any given point on the curve. Increasing the degree increases continuity.
                                           # If not defined, the default value is 1.
 


### PR DESCRIPTION
Changes for getting VDA5050 controller to work on real machine.

- Rename informations to information to meet VDA standard
- Use v2 as default standard version
- Handle not processing nodes if we get a startPause action
- Use last base node (not last node) when processing an order update
- Add orientation type to Edge message
- Change trajectory.degree to int32 to account for Navitec bug. They fail to process the state message if it is a float 