### PR TITLE
feat: limit num of errors logged in the state message S587-2332

### DIFF
--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -121,6 +121,7 @@ DEFAULT_EXECUTE_ORDER_PERIOD = 0.1  # sec
 # JLG_CHANGES_START
 # Maximum number of errors retained in the state. Older errors are dropped to
 # prevent the state message from growing unbounded (e.g. repeated goal rejections).
+# https://jlgaccessit.atlassian.net/browse/S587-2331
 MAX_RETAINED_ERRORS = 25
 # JLG_CHANGES_END
 
@@ -498,6 +499,7 @@ class VDA5050Controller(Node):
         # JLG_CHANGES_START
         # Cap retained errors to the most recent ones to keep the state message
         # from growing unbounded when errors are appended repeatedly.
+        # https://jlgaccessit.atlassian.net/browse/S587-2331
         if "errors" in partial_state and len(self._current_state.errors) > MAX_RETAINED_ERRORS:
             self._current_state.errors = self._current_state.errors[-MAX_RETAINED_ERRORS:]
         # JLG_CHANGES_END

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -118,6 +118,12 @@ DEFAULT_CONNECTION_PUB_PERIOD = 15.0  # sec
 DEFAULT_VISUALIZATION_PUB_PERIOD = 1.0  # sec
 DEFAULT_EXECUTE_ORDER_PERIOD = 0.1  # sec
 
+# JLG_CHANGES_START
+# Maximum number of errors retained in the state. Older errors are dropped to
+# prevent the state message from growing unbounded (e.g. repeated goal rejections).
+MAX_RETAINED_ERRORS = 25
+# JLG_CHANGES_END
+
 
 class ActionErrors(Enum):
     """Action Error types."""
@@ -488,6 +494,13 @@ class VDA5050Controller(Node):
         """
         for k, v in partial_state.items():
             setattr(self._current_state, k, v)
+
+        # JLG_CHANGES_START
+        # Cap retained errors to the most recent ones to keep the state message
+        # from growing unbounded when errors are appended repeatedly.
+        if "errors" in partial_state and len(self._current_state.errors) > MAX_RETAINED_ERRORS:
+            self._current_state.errors = self._current_state.errors[-MAX_RETAINED_ERRORS:]
+        # JLG_CHANGES_END
 
         self.logger.debug(f"State updated: '{self._current_state}'.")
         if publish_now:


### PR DESCRIPTION
this is just a band aid to pretect for what happened the other day with that AMR that started accumulating errors in the state message. I want to find the root cause of it, but I think it's harmless to limit the errors field to the last 25 errors. 