### PR TITLE
feat: update state msg before publishing the state message S587-2394

### DIFF
--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -455,6 +455,9 @@ class VDA5050Controller(Node):
 
     def _publish_state(self):
         """Publish the current OrderState msg."""
+        # JLG_CHANGES_START
+        self.get_state_from_adapter()
+        # JLG_CHANGES_END
         self.logger.debug(f"Publishing state message {self._current_state}")
         self._current_state.header_id += 1
         self._current_state.timestamp = get_vda5050_ts()


### PR DESCRIPTION
While investigating why some AMRs stop correctly reporting DTCs in the state message, I noticed that, on idle, the only way the state message updates if by the `_publish_visualization` method.
This is fine since we publish the visualization topic once a second, it's not an optimal way to do it. I think the `get_state_from_adapter()` methods needs to be called independently.

This PR is just a placeholder until I have time to properly address this. 