### PR TITLE
fix: proper action states handling S587-2421

### DIFF
--- a/vda5050_connector/test/test_vda5050_controller.py
+++ b/vda5050_connector/test/test_vda5050_controller.py
@@ -37,6 +37,7 @@ from uuid import uuid4
 
 from vda5050_connector_py.vda5050_controller import VDA5050Controller
 from vda5050_connector_py.vda5050_controller import OrderAcceptModes
+from vda5050_connector_py.vda5050_controller import OrderExecutionErrors
 from vda5050_connector_py.vda5050_controller import OrderRejectErrors
 from vda5050_connector_py.utils import get_vda5050_ts
 from vda5050_connector.action import NavigateToNode
@@ -47,6 +48,7 @@ from vda5050_msgs.msg import Edge
 from vda5050_msgs.msg import NodePosition
 from vda5050_msgs.msg import Action
 from vda5050_msgs.msg import ActionParameter
+from vda5050_msgs.msg import CurrentAction
 
 
 def get_order_new(order_id=str(uuid4()), order_update_id=0):
@@ -365,6 +367,86 @@ def get_stitch_orders(order_id=str(uuid4())):
     return [base_order, stitch_order]
 
 
+def get_stitch_orders_no_actions_on_stitch_node(order_id=str(uuid4())):
+    """Build a base / stitch order pair where the stitch node (node2) has no actions."""
+    action1 = Action(
+        action_type="foo",
+        action_id=str(uuid4()),
+        action_description="Foo description",
+        blocking_type="NONE",
+    )
+    action3 = Action(
+        action_type="foobar",
+        action_id=str(uuid4()),
+        action_description="FooBar description",
+        blocking_type="NONE",
+    )
+    node1 = Node(
+        node_id="node1",
+        sequence_id=0,
+        released=True,
+        node_position=NodePosition(x=2.0, y=0.95, theta=-0.66, map_id="map"),
+        actions=[action1],
+    )
+    node3 = Node(
+        node_id="node3",
+        sequence_id=4,
+        released=True,
+        node_position=NodePosition(x=-0.38, y=1.89, theta=0.0, map_id="map"),
+        actions=[action3],
+    )
+
+    def build_node2():
+        return Node(
+            node_id="node2",
+            sequence_id=2,
+            released=True,
+            node_position=NodePosition(x=1.18, y=-1.76, theta=0.0, map_id="map"),
+        )
+
+    base_order = Order(
+        header_id=0,
+        timestamp=get_vda5050_ts(),
+        version="1.1.1",
+        manufacturer="MANUFACTURER",
+        serial_number="SERIAL_NUMBER",
+        order_id=order_id,
+        order_update_id=0,
+        nodes=[node1, build_node2()],
+        edges=[
+            Edge(
+                edge_id="edge1",
+                sequence_id=1,
+                released=True,
+                start_node_id="node1",
+                end_node_id="node2",
+            ),
+        ],
+    )
+
+    stitch_order = Order(
+        header_id=0,
+        timestamp=get_vda5050_ts(),
+        version="1.1.1",
+        manufacturer="MANUFACTURER",
+        serial_number="SERIAL_NUMBER",
+        order_id=order_id,
+        order_update_id=1,
+        nodes=[build_node2(), node3],
+        edges=[
+            Edge(
+                edge_id="edge2",
+                sequence_id=3,
+                released=True,
+                start_node_id="node2",
+                end_node_id="node3",
+            ),
+        ],
+    )
+
+    return [base_order, stitch_order]
+
+
 def test_vda5050_controller_node_new_order(
     mocker,
     adapter_node,
@@ -622,6 +704,99 @@ def test_vda5050_controller_node_stitch_order(
 
     assert node._current_state.last_node_id == "node3"
     assert node._current_state.last_node_sequence_id == 4
+
+
+def test_vda5050_controller_node_stitch_order_without_actions_on_stitch_node(
+    mocker,
+    adapter_node,
+    action_server_nav_to_node,
+    action_server_process_vda_action,
+    service_get_state,
+    service_supported_actions,
+):
+    """Stitching on an action-less node must not drop the already tracked action states."""
+    node = VDA5050Controller()
+    node.logger.set_level(LoggingSeverity.DEBUG)
+
+    spy_accept_order = mocker.spy(node, "_accept_order")
+
+    [base_order, stitch_order] = get_stitch_orders_no_actions_on_stitch_node()
+    action1 = base_order.nodes[0].actions[0]
+    action3 = stitch_order.nodes[1].actions[0]
+
+    node.process_order(base_order)
+    assert len(node._current_state.action_states) == 1
+
+    node._update_action_status(action1.action_id, CurrentAction.FINISHED)
+
+    spy_accept_order.reset_mock()
+    node.process_order(stitch_order)
+    spy_accept_order.assert_called_once_with(order=stitch_order, mode=OrderAcceptModes.STITCH)
+
+    action_states = {
+        action_state.action_id: action_state
+        for action_state in node._current_state.action_states
+    }
+    assert len(action_states) == 2
+    assert action_states[action1.action_id].action_status == CurrentAction.FINISHED
+    assert action_states[action3.action_id].action_status == CurrentAction.WAITING
+
+
+def test_vda5050_controller_execute_node_actions_restores_untracked_action(
+    mocker,
+    adapter_node,
+    action_server_nav_to_node,
+    action_server_process_vda_action,
+    service_get_state,
+    service_supported_actions,
+):
+    """An action without a matching action state is restored instead of crashing the node."""
+    node = VDA5050Controller()
+    node.logger.set_level(LoggingSeverity.DEBUG)
+
+    mock_send_action = mocker.patch.object(node, "send_adapter_process_vda_action")
+
+    action = Action(
+        action_type="foo",
+        action_id=str(uuid4()),
+        action_description="Foo description",
+        blocking_type="HARD",
+    )
+    node._current_node_actions = [action]
+    node._current_state.action_states = []
+
+    node._execute_node_actions()
+
+    assert len(node._current_state.action_states) == 1
+    assert node._current_state.action_states[0].action_id == action.action_id
+    assert node._current_state.action_states[0].action_status == CurrentAction.WAITING
+    mock_send_action.assert_called_once_with(action)
+
+
+def test_vda5050_controller_on_active_order_reports_unhandled_exceptions(
+    mocker,
+    adapter_node,
+    action_server_nav_to_node,
+    action_server_process_vda_action,
+    service_get_state,
+    service_supported_actions,
+):
+    """An unhandled exception is reported once instead of killing the controller."""
+    node = VDA5050Controller()
+    node.logger.set_level(LoggingSeverity.DEBUG)
+
+    mocker.patch.object(node, "_has_current_order", side_effect=RuntimeError("boom"))
+
+    node._on_active_order()
+    node._on_active_order()
+
+    internal_errors = [
+        error
+        for error in node._current_state.errors
+        if error.error_type == OrderExecutionErrors.INTERNAL_ERROR.value
+    ]
+    assert len(internal_errors) == 1
+    assert "boom" in internal_errors[0].error_description
 
 
 def test_vda5050_controller_node_reject_order(

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -37,6 +37,8 @@ import itertools
 import functools
 import traceback
 
+from pyparsing import Optional
+
 # ROS dependencies / utils
 from rclpy.action import ActionClient
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
@@ -599,7 +601,7 @@ class VDA5050Controller(Node):
         self.logger.debug("Deleting action states.")
         self._update_state({"action_states": []})
 
-    def _get_action_status(self, action_id: str) -> str:
+    def _get_action_status(self, action_id: str) -> "Optional[str]":
         """
         Get the action status on the current state given action's ID.
 

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -35,6 +35,7 @@
 from enum import Enum
 import itertools
 import functools
+import traceback
 
 # ROS dependencies / utils
 from rclpy.action import ActionClient
@@ -150,6 +151,7 @@ class OrderExecutionErrors(Enum):
     """Order Processing - Execution Error types."""
 
     NAVIGATION_ERROR = "navigationError"
+    INTERNAL_ERROR = "internalError"
 
 # JLG_CHANGES_END
 
@@ -607,7 +609,8 @@ class VDA5050Controller(Node):
 
         Returns
         -------
-            action_status (str): Action status
+            action_status (str): Action status, or None if the action is not tracked
+                on the current state.
                 ``VDACurrentAction.WAITING``
                 ``VDACurrentAction.INITIALIZING``
                 ``VDACurrentAction.RUNNING``
@@ -624,6 +627,13 @@ class VDA5050Controller(Node):
             ),
             None,
         )
+        # JLG_CHANGES_START
+        if action_state is None:
+            self.logger.error(
+                f"Couldn't find action with id: '{action_id}' to get its status."
+            )
+            return None
+        # JLG_CHANGES_END
         return action_state.action_status
 
     def _update_action_status(self, action_id: str, action_status: str, result_description: str = ""):
@@ -1334,6 +1344,23 @@ class VDA5050Controller(Node):
             # JLG_CHANGES_END
         ]
 
+        # JLG_CHANGES_START
+        # On stitching, the stitch node's actions are already tracked, so append only the
+        # actions that are not tracked yet. This preserves their current status and avoids
+        # dropping unrelated (edge / instant) action states.
+        if mode == OrderAcceptModes.STITCH:
+            tracked_action_ids = {
+                action_state.action_id for action_state in self._current_state.action_states
+            }
+            action_states = self._current_state.action_states + [
+                action_state
+                for action_state in self._get_action_states(order)
+                if action_state.action_id not in tracked_action_ids
+            ]
+        else:
+            action_states = self._get_action_states(order)
+        # JLG_CHANGES_END
+
         # Update state
         # Only on stitching updates the node and edges base states are kept
         self._update_state(
@@ -1345,8 +1372,7 @@ class VDA5050Controller(Node):
                 + self._get_node_states(order),
                 "edge_states": (mode == OrderAcceptModes.STITCH) * self._current_state.edge_states
                 + self._get_edge_states(order),
-                "action_states": self._current_state.action_states[:-len(order.nodes[0].actions)]
-                + self._get_action_states(order),
+                "action_states": action_states,
                 "new_base_request": False,
             }
         )
@@ -1569,6 +1595,45 @@ class VDA5050Controller(Node):
 
     def _on_active_order(self):
         """
+        Run the order state machine, shielding the executor from any failure.
+
+        An exception escaping a timer callback tears down the rclpy executor and kills the
+        controller process, stranding the robot mid-order. Report it instead.
+        """
+        # JLG_CHANGES_START
+        try:
+            self._on_active_order_impl()
+        except Exception as ex:
+            self.logger.error(
+                f"Unhandled exception while executing the order: {ex}\n{traceback.format_exc()}",
+                throttle_duration_sec=5,
+            )
+
+            error_description = f"Unhandled exception while executing the order: {ex}"
+            already_reported = any(
+                error.error_type == OrderExecutionErrors.INTERNAL_ERROR.value
+                and error.error_description == error_description
+                for error in self._current_state.errors
+            )
+            if not already_reported:
+                error = VDAError(
+                    error_type=OrderExecutionErrors.INTERNAL_ERROR.value,
+                    error_description=error_description,
+                    error_level=VDAError.FATAL,
+                    error_references=[
+                        VDAErrorReference(
+                            reference_key="order_id",
+                            reference_value=self._current_state.order_id,
+                        )
+                    ],
+                )
+                self._update_state(
+                    {"errors": self._current_state.errors + [error]}, publish_now=True
+                )
+        # JLG_CHANGES_END
+
+    def _on_active_order_impl(self):
+        """
         Execute order state machine.
 
         It first checks if there is an instruction to cancel the order.
@@ -1660,6 +1725,47 @@ class VDA5050Controller(Node):
         This same function filters any finished / failed action from the current node actions.
 
         """
+        # JLG_CHANGES_START
+        # Re-register actions that lost their state, otherwise they would never leave the
+        # WAITING check in send_adapter_process_vda_action and the order would stall.
+        untracked_actions = [
+            action
+            for action in self._current_node_actions
+            if self._get_action_status(action.action_id) is None
+        ]
+        if untracked_actions:
+            self._update_state({
+                "action_states": self._current_state.action_states + [
+                    VDACurrentAction(
+                        action_id=action.action_id,
+                        action_type=action.action_type,
+                        action_description=action.action_description,
+                        action_status=VDACurrentAction.WAITING,
+                    )
+                    for action in untracked_actions
+                ]
+            })
+            errors = [
+                VDAError(
+                    error_type=ActionErrors.ACTION_NOT_FOUND.value,
+                    error_description=(
+                        f"VDA5050 action with id {action.action_id} was missing from the"
+                        " action states and has been restored as WAITING"
+                    ),
+                    error_level=VDAError.WARNING,
+                    error_references=[
+                        VDAErrorReference(
+                            reference_key="action_id", reference_value=action.action_id
+                        )
+                    ],
+                )
+                for action in untracked_actions
+            ]
+            current_errors = self._current_state.errors
+            self._update_state({"errors": current_errors + errors}, publish_now=True)
+            self._update_state({"errors": current_errors})
+        # JLG_CHANGES_END
+
         # Remove finished / failed actions
         self._current_node_actions = [
             action


### PR DESCRIPTION
## fix: proper action states handling

### Problem

The `vda5050_controller` node crashes and the process dies mid-order:

```
File ".../vda5050_controller.py", line 611, in _get_action_status
    return action_state.action_status
AttributeError: 'NoneType' object has no attribute 'action_status'
[ERROR] [vda5050_controller.py-7]: process has died [pid 45, exit code 1, ...]
```

### Root cause

In `_accept_order`:

```python
"action_states": self._current_state.action_states[:-len(order.nodes[0].actions)]
+ self._get_action_states(order),
```

When the stitch node carries no actions, `len(...) == 0` and Python evaluates `action_states[:-0]` as `action_states[:0]` → `[]`. **Every stitch/update whose first node has no actions wipes the entire action-state array.**

Observed sequence for order `c855eac7-fda2-45d4-ba59-561898312205`:

| Update | Stitch node | Effect |
|---|---|---|
| 0 (NEW) | `S-6144` | 2 WAITING states created for node `6144-6140` (`setScannerPattern`, `personalitySwitch`, both HARD) |
| 1 (STITCH) | `6140-6136`, `actions: []` | `[:-0]` → `action_states` wiped |
| 2 (STITCH) | `8088-8084`, `actions: []` | still empty |

The robot then arrives at `6144-6140`, `_process_node` sets `_current_node_actions` to its 2 actions ("Executing 2 actions of node: 6144-6140."), and `_execute_node_actions` looks up statuses that no longer exist. The `AttributeError` escapes the 10 Hz timer callback, propagates through the rclpy executor, and kills the process.

Two related defects in the same expression: the slice drops the **last** N entries, which are not necessarily the stitch node's states (`_get_action_states` appends node actions then *edge* actions, and instant actions are appended to the same array), and rebuilding the stitch node's states resets in-progress actions back to `WAITING`.

### Changes

1. **`_accept_order`** — replaced the slice with an id-based merge. On `STITCH`, keep the current states and append only action states whose `action_id` isn't tracked yet; otherwise use `_get_action_states(order)`. Preserves `RUNNING`/`FINISHED` statuses and never drops edge or instant action states.
2. **`_get_action_status`** — returns `None` with an error log instead of dereferencing `None`.
3. **`_execute_node_actions`** — re-registers any node action missing from `action_states` as `WAITING` and publishes an `actionNotFound` warning. Without this, `send_adapter_process_vda_action` (which early-returns for any status ≠ `WAITING`) would convert the crash into a silent stall with the order stuck forever.
4. **`_on_active_order`** — split into a guard plus `_on_active_order_impl`, mirroring the existing `_navigate_through_nodes_result_callback` / `_..._impl` pattern. Catches `Exception` (not `BaseException`, so `SIGINT` still works), logs a throttled traceback, and publishes a FATAL `internalError` once per distinct failure so the 10 Hz timer doesn't spam the state topic. `_accept_order` already strips `OrderExecutionErrors` types, so it self-clears on the next order. A crashed controller strands the AMR mid-order; reporting is strictly better than dying.

### Tests

- `test_vda5050_controller_node_stitch_order_without_actions_on_stitch_node` — base order with an action on `node1` and an action-less stitch node; asserts the `FINISHED` state survives the stitch and only the new action is appended as `WAITING`. Fails without change 1.
- `test_vda5050_controller_execute_node_actions_restores_untracked_action` — an action with no matching state is restored and still dispatched instead of raising.
- `test_vda5050_controller_on_active_order_reports_unhandled_exceptions` — a raising internal call is swallowed and reported exactly once.

The pre-existing `test_vda5050_controller_node_stitch_order` missed this because `get_stitch_orders()` gives *every* node an action, so `len(nodes[0].actions)` is never 0.

### Notes

Upstream `inorbit-ai/ros_amr_interop@humble-devel` fixed the same line with an equivalent id-based merge, which keeps this fork mergeable.